### PR TITLE
fix closeApp on chromecast (DIAL)

### DIFF
--- a/ConnectSDK/Services/DIALService.m
+++ b/ConnectSDK/Services/DIALService.m
@@ -468,7 +468,7 @@ static NSMutableArray *registeredApps = nil;
     }
     
     NSString *commandPath = [NSString stringWithFormat:@"http://%@:%@", self.serviceDescription.commandURL.host, self.serviceDescription.commandURL.port];
-    if ([launchSession.sessionId hasPrefix:commandPath])
+    if ([launchSession.sessionId hasPrefix:@"http://"] || [launchSession.sessionId hasPrefix:@"https://"])
       commandPath = launchSession.sessionId;//chromecast returns full url
     else
       commandPath = [commandPath stringByAppendingPathComponent:launchSession.sessionId];


### PR DESCRIPTION
for chromecast (and maybe other), sessionId (from Location header) is full url already (http://<ip>:<port>/<appname>-<number>). We should send DELETE request to that url directly instead of building it (result in bad url).
