### PR TITLE
fix crashed with lg tv caused by DCHECK(_source != NULL);

### DIFF
--- a/ConnectSDK/Services/NetcastTVService.m
+++ b/ConnectSDK/Services/NetcastTVService.m
@@ -445,7 +445,10 @@ NSString *lgeUDAPRequestURI[8] = {
 {
     if (_subscriptionServer)
     {
-        [_subscriptionServer stop];
+        if ([_subscriptionServer isRunning])
+        {
+            [_subscriptionServer stop];
+        }
         _subscriptionServer = nil;
     }
 }


### PR DESCRIPTION
to reproduce the issue:
- open Connect-SDK-Cordova-API-Sampler on ios simulator
- connect lg smart tv
- disconnect -> will crash app
