### PR TITLE
Use GCDWebServer from a pod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = dev
 [submodule "core"]
 	path = core
-	url = https://github.com/ConnectSDK/Connect-SDK-iOS-Core.git
+	url = https://github.com/sergiou87/Connect-SDK-iOS-Core.git
 	branch = dev

--- a/ConnectSDK.podspec
+++ b/ConnectSDK.podspec
@@ -81,8 +81,8 @@ Pod::Spec.new do |s|
     sp.dependency 'ConnectSDK/Core'
     sp.source_files = "modules/**/*.{h,m}"
     sp.private_header_files = "modules/**/*_Private.h"
-    
-    cast_version = "2.5.1"
+
+    cast_version = "2.5.2"
     sp.dependency "google-cast-sdk", cast_version
     sp.framework = "GoogleCast"
     sp.xcconfig = {

--- a/ConnectSDK.podspec
+++ b/ConnectSDK.podspec
@@ -69,6 +69,7 @@ Pod::Spec.new do |s|
     sp.requires_arc = true
 
     sp.dependency 'ConnectSDK/no-arc'
+    sp.dependency 'GCDWebServer', '~> 3.2'
   end
 
   s.subspec 'no-arc' do |sp|


### PR DESCRIPTION
This pull request depends on this one: ___________________

The problem is our project depends on `GCDWebServer` pod, with the `WebDav` sub-pod, and having these files also in `ConnectSDK` results in build errors because of having duplicated definitions of `GCDWebServer` classes.

So I have deleted these files here and added `GCDWebServer` as a pod dependency in the `ConnectSDK/Core` podspec.

IMHO this should be done with the rest of the dependencies, what do you think?