### PR TITLE
README: add status badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
   - mv -v ios-sdk/frameworks/{AmazonFling,third_party_framework/Bolts}.framework modules/firetv/Frameworks/
 
 script:
-  - xctool -scheme ConnectSDK -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/build_ccov" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES build test
-  - xctool -scheme ConnectSDKIntegrationTests -configuration Debug -sdk iphonesimulator build test
+  - xctool -scheme ConnectSDK -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/tests_build" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES build test
+  - xctool -scheme ConnectSDKIntegrationTests -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/integration_tests_build" test
 
 after_success:
-  - gcovr --object-directory="out/build_ccov/ConnectSDK/Build/Intermediates/ConnectSDK.build/Debug-iphonesimulator/ConnectSDK.build/Objects-normal/i386/" --root=. --xml-pretty --gcov-exclude='.*#(?:\w*Tests|Frameworks)#.*' --print-summary --output="cobertura.xml"
+  - gcovr --object-directory="out/tests_build/ConnectSDK/Build/Intermediates/ConnectSDK.build/Debug-iphonesimulator/ConnectSDK.build/Objects-normal/i386/" --root=. --xml-pretty --gcov-exclude='.*#(?:\w*Tests|Frameworks)#.*' --print-summary --output="cobertura.xml"
   - bash <(curl -s https://codecov.io/bash) -f "cobertura.xml"
 
 # vim: set sw=2 ts=2 sts=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: objective-c
 osx_image: xcode6.4
 
+install:
+  - brew install gcovr
+
 before_script:
   - curl -L -ocast.zip https://redirector.gvt1.com/edgedl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip
   - unzip cast.zip 'GoogleCastSDK-2.7.1-Release/GoogleCast.framework/*'
@@ -10,7 +13,11 @@ before_script:
   - mv -v ios-sdk/frameworks/{AmazonFling,third_party_framework/Bolts}.framework modules/firetv/Frameworks/
 
 script:
-  - xctool -scheme ConnectSDK -sdk iphonesimulator build test
-  - xctool -scheme ConnectSDKIntegrationTests -sdk iphonesimulator build test
+  - xctool -scheme ConnectSDK -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/build_ccov" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES build test
+  - xctool -scheme ConnectSDKIntegrationTests -configuration Debug -sdk iphonesimulator build test
+
+after_success:
+  - gcovr --object-directory="out/build_ccov/ConnectSDK/Build/Intermediates/ConnectSDK.build/Debug-iphonesimulator/ConnectSDK.build/Objects-normal/i386/" --root=. --xml-pretty --gcov-exclude='.*#(?:\w*Tests|Frameworks)#.*' --print-summary --output="cobertura.xml"
+  - bash <(curl -s https://codecov.io/bash) -f "cobertura.xml"
 
 # vim: set sw=2 ts=2 sts=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,13 @@ osx_image: xcode6.4
 xcode_project: ConnectSDK.xcodeproj
 xcode_scheme: ConnectSDKTests
 xcode_sdk: iphonesimulator
+
+before_script:
+  - curl -L -ocast.zip https://redirector.gvt1.com/edgedl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip
+  - unzip cast.zip 'GoogleCastSDK-2.7.1-Release/GoogleCast.framework/*'
+  - mv -v GoogleCastSDK-2.7.1-Release/GoogleCast.framework modules/google-cast/
+  - curl -L -ofling.zip https://s3-us-west-1.amazonaws.com/amazon-fling/AmazonFling-SDK.zip
+  - unzip fling.zip 'ios-sdk/frameworks/*'
+  - mv -v ios-sdk/frameworks/{AmazonFling,third_party_framework/Bolts}.framework modules/firetv/Frameworks/
+
+# vim: set sw=2 ts=2 sts=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: objective-c
 osx_image: xcode6.4
 
-xcode_project: ConnectSDK.xcodeproj
-xcode_scheme: ConnectSDKTests
-xcode_sdk: iphonesimulator
-
 before_script:
   - curl -L -ocast.zip https://redirector.gvt1.com/edgedl/chromecast/sdk/ios/GoogleCastSDK-2.7.1-Release-ios-default.zip
   - unzip cast.zip 'GoogleCastSDK-2.7.1-Release/GoogleCast.framework/*'
@@ -12,5 +8,9 @@ before_script:
   - curl -L -ofling.zip https://s3-us-west-1.amazonaws.com/amazon-fling/AmazonFling-SDK.zip
   - unzip fling.zip 'ios-sdk/frameworks/*'
   - mv -v ios-sdk/frameworks/{AmazonFling,third_party_framework/Bolts}.framework modules/firetv/Frameworks/
+
+script:
+  - xctool -scheme ConnectSDK -sdk iphonesimulator build test
+  - xctool -scheme ConnectSDKIntegrationTests -sdk iphonesimulator build test
 
 # vim: set sw=2 ts=2 sts=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: objective-c
+osx_image: xcode6.4
+
+xcode_project: ConnectSDK.xcodeproj
+xcode_scheme: ConnectSDKTests
+xcode_sdk: iphonesimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - mv -v ios-sdk/frameworks/{AmazonFling,third_party_framework/Bolts}.framework modules/firetv/Frameworks/
 
 script:
-  - xctool -scheme ConnectSDK -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/tests_build" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES build test
+  - xctool -scheme ConnectSDK -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/tests_build" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES test
   - xctool -scheme ConnectSDKIntegrationTests -configuration Debug -sdk iphonesimulator -IDECustomDerivedDataLocation="out/integration_tests_build" test
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 [![Build Status](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS.svg)](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS)
 [![Code Coverage](https://img.shields.io/codecov/c/github/ConnectSDK/Connect-SDK-iOS/dev.svg)](https://codecov.io/github/ConnectSDK/Connect-SDK-iOS)
-
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ConnectSDK.svg)](https://cocoapods.org/pods/ConnectSDK)
 [![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)
 [![Platform: iOS](https://img.shields.io/cocoapods/p/ConnectSDK.svg)](http://cocoadocs.org/docsets/ConnectSDK/)
-
 [![Twitter: @ConnectSDK](https://img.shields.io/badge/twitter-@ConnectSDK-blue.svg)](https://twitter.com/ConnectSDK)
 
 Connect SDK is an open source framework that connects your mobile apps with multiple TV platforms. Because most TV platforms support a variety of protocols, Connect SDK integrates and abstracts the discovery and connectivity between all supported protocols.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 #Connect SDK iOS
+
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ConnectSDK.svg)](https://cocoapods.org/pods/ConnectSDK)
+[![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)
+[![Platform: iOS](https://img.shields.io/cocoapods/p/ConnectSDK.svg)](http://cocoadocs.org/docsets/ConnectSDK/)
+
 Connect SDK is an open source framework that connects your mobile apps with multiple TV platforms. Because most TV platforms support a variety of protocols, Connect SDK integrates and abstracts the discovery and connectivity between all supported protocols.
 
 For more information, visit our [website](http://www.connectsdk.com/).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)
 [![Platform: iOS](https://img.shields.io/cocoapods/p/ConnectSDK.svg)](http://cocoadocs.org/docsets/ConnectSDK/)
 
+![Twitter: @ConnectSDK](https://img.shields.io/badge/twitter-@ConnectSDK-blue.svg)
+
 Connect SDK is an open source framework that connects your mobile apps with multiple TV platforms. Because most TV platforms support a variety of protocols, Connect SDK integrates and abstracts the discovery and connectivity between all supported protocols.
 
 For more information, visit our [website](http://www.connectsdk.com/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Connect SDK iOS
 
+[![Build Status](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS.svg)](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS)
+
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ConnectSDK.svg)](https://cocoapods.org/pods/ConnectSDK)
 [![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)
 [![Platform: iOS](https://img.shields.io/cocoapods/p/ConnectSDK.svg)](http://cocoadocs.org/docsets/ConnectSDK/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #Connect SDK iOS
 
 [![Build Status](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS.svg)](https://travis-ci.org/ConnectSDK/Connect-SDK-iOS)
+[![Code Coverage](https://img.shields.io/codecov/c/github/ConnectSDK/Connect-SDK-iOS/dev.svg)](https://codecov.io/github/ConnectSDK/Connect-SDK-iOS)
 
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ConnectSDK.svg)](https://cocoapods.org/pods/ConnectSDK)
 [![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Apache License, 2.0](https://img.shields.io/cocoapods/l/ConnectSDK.svg)](https://github.com/ConnectSDK/Connect-SDK-iOS/blob/master/LICENSE)
 [![Platform: iOS](https://img.shields.io/cocoapods/p/ConnectSDK.svg)](http://cocoadocs.org/docsets/ConnectSDK/)
 
-![Twitter: @ConnectSDK](https://img.shields.io/badge/twitter-@ConnectSDK-blue.svg)
+[![Twitter: @ConnectSDK](https://img.shields.io/badge/twitter-@ConnectSDK-blue.svg)](https://twitter.com/ConnectSDK)
 
 Connect SDK is an open source framework that connects your mobile apps with multiple TV platforms. Because most TV platforms support a variety of protocols, Connect SDK integrates and abstracts the discovery and connectivity between all supported protocols.
 


### PR DESCRIPTION
This patch adds a few badges to the project's `README`:
* build status and code coverage (**NB**: the current links and images do not work until this PR is merged into main `dev`; here are my current badges: [![](https://api.travis-ci.org/eunikolsky/Connect-SDK-iOS.svg)](https://travis-ci.org/eunikolsky/Connect-SDK-iOS) and [![](https://img.shields.io/codecov/c/github/eunikolsky/Connect-SDK-iOS/feature/173_badges.svg)](https://codecov.io/github/eunikolsky/Connect-SDK-iOS));
* latest version on CocoaPods, license, and iOS platform;
* twitter.

Anything else that would be useful?

Implements #173.