### PR TITLE
Remove debug symbols from the library in Release configuration

### DIFF
--- a/ConnectSDK.xcodeproj/project.pbxproj
+++ b/ConnectSDK.xcodeproj/project.pbxproj
@@ -2495,6 +2495,7 @@
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = NO;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				DSTROOT = /tmp/Connect_SDK.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2502,6 +2503,7 @@
 					"$(PROJECT_DIR)/modules/google-cast",
 					"$(PROJECT_DIR)/modules/firetv/Frameworks",
 				);
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "core/ConnectSDK-Prefix.pch";
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;


### PR DESCRIPTION
This allows to decrease the framework size (with four architectures)
from 23.8 MiB to 11.7 MiB (current values).

Implements https://github.com/ConnectSDK/Connect-SDK-iOS/issues/133